### PR TITLE
Linux support

### DIFF
--- a/src/PersonaEngine/PersonaEngine.App/appsettings.json
+++ b/src/PersonaEngine/PersonaEngine.App/appsettings.json
@@ -23,6 +23,7 @@
       "VadMinSilenceDuration": 450
     },
     "Microphone": {
+      "InputEngine": "portaudio",
       "DeviceName": ""
     },
     "Tts": {
@@ -58,6 +59,7 @@
       "Height": 1920
     },
     "Live2D": {
+      "Enabled": false,
       "ModelPath": "Resources/Live2D/Avatars",
       "ModelName": "aria",
       "Width": 1080,
@@ -75,6 +77,21 @@
         "Height": 1080
       }
     ],
+    "Spout": {
+      "Enabled": false,
+      "Outputs": [
+        {
+          "Name": "Live2D",
+          "Width": 1080,
+          "Height": 1920
+        },
+        {
+          "Name": "RouletteWheel",
+          "Width": 1080,
+          "Height": 1080
+        }
+      ]
+    },
     "Vision": {
       "WindowTitle": "Microsoft Edge",
       "Enabled": false,

--- a/src/PersonaEngine/PersonaEngine.App/appsettings.json
+++ b/src/PersonaEngine/PersonaEngine.App/appsettings.json
@@ -65,18 +65,6 @@
       "Width": 1080,
       "Height": 1920
     },
-    "SpoutConfigs": [
-      {
-        "OutputName": "Live2D",
-        "Width": 1080,
-        "Height": 1920
-      },
-      {
-        "OutputName": "RouletteWheel",
-        "Width": 1080,
-        "Height": 1080
-      }
-    ],
     "Spout": {
       "Enabled": false,
       "Outputs": [

--- a/src/PersonaEngine/PersonaEngine.Lib/Audio/MicrophoneInputPortAudioSource.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/Audio/MicrophoneInputPortAudioSource.cs
@@ -133,7 +133,8 @@ public sealed class MicrophoneInputPortAudioSource : AwaitableWaveFileSource, IM
 
     public IEnumerable<string> GetAvailableDevices()
     {
-        throw new NotImplementedException();
+        // throw new NotImplementedException();
+        return new List<string>();
     }
 
     private void InitializeAudioStream()

--- a/src/PersonaEngine/PersonaEngine.Lib/Configuration/AvatarAppConfig.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/Configuration/AvatarAppConfig.cs
@@ -18,7 +18,7 @@ public record AvatarAppConfig
 
     public Live2DOptions Live2D { get; set; } = new();
 
-    public SpoutConfiguration[] SpoutConfigs { get; set; } = [];
+    public SpoutConfiguration SpoutConfigs { get; set; } = new();
 
     public VisionConfig Vision { get; set; } = new();
 

--- a/src/PersonaEngine/PersonaEngine.Lib/Configuration/Live2DOptions.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/Configuration/Live2DOptions.cs
@@ -2,6 +2,8 @@
 
 public class Live2DOptions
 {
+    public bool Enabled { get; set; } = false;
+    
     public string ModelPath { get; set; } = "Resources/Live2D/Avatars";
 
     public string ModelName { get; set; } = "angel";

--- a/src/PersonaEngine/PersonaEngine.Lib/Configuration/MicrophoneConfiguration.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/Configuration/MicrophoneConfiguration.cs
@@ -6,5 +6,8 @@ public record MicrophoneConfiguration
     ///     The friendly name of the desired input device.
     ///     If null, empty, or whitespace, the default device (DeviceNumber 0) will be used.
     /// </summary>
+    
+    public string? InputEngine { get; init; } = null;
+
     public string? DeviceName { get; init; } = null;
 }

--- a/src/PersonaEngine/PersonaEngine.Lib/Configuration/SpoutConfiguration.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/Configuration/SpoutConfiguration.cs
@@ -2,9 +2,7 @@
 
 public record SpoutConfiguration
 {
-    public required string OutputName { get; init; }
-
-    public required int Width { get; init; }
-
-    public required int Height { get; init; }
+    public bool Enabled { get; set; } = false;
+    
+    public SpoutOutputConfigurations[] Outputs { get; set; } = [];
 }

--- a/src/PersonaEngine/PersonaEngine.Lib/Configuration/SpoutOutputConfigurations.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/Configuration/SpoutOutputConfigurations.cs
@@ -1,0 +1,10 @@
+namespace PersonaEngine.Lib.Configuration;
+
+public class SpoutOutputConfigurations
+{
+    public required string Name { get; init; }
+
+    public required int Width { get; init; }
+
+    public required int Height { get; init; }
+}

--- a/src/PersonaEngine/PersonaEngine.Lib/Core/AvatarApp.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/Core/AvatarApp.cs
@@ -101,9 +101,19 @@ public class AvatarApp : IDisposable
             task.Execute(_gl);
         }
 
-        _spoutRegistry = new SpoutRegistry(_gl, _config.Value.SpoutConfigs);
+        if (_config.Value.SpoutConfigs?.Enabled == true)
+        {
+            _spoutRegistry = new SpoutRegistry(_gl, _config.Value.SpoutConfigs);
+        }
+        else
+        {
+            // Use null object pattern
+            _spoutRegistry = new NullSpoutRegistry();
+        }
 
-        _imGui = new ImGuiController(_gl, _window, _inputContext, Path.Combine(@"Resources\Fonts", @"Montserrat-Medium.ttf"), Path.Combine(@"Resources\Fonts", @"seguiemj.ttf"));
+        _imGui = new ImGuiController(_gl, _window, _inputContext, 
+            Path.Combine("Resources", "Fonts", "Montserrat-Medium.ttf"), 
+            Path.Combine("Resources", "Fonts", "seguiemj.ttf"));
 
         InitializeComponents(_regularComponents);
 
@@ -156,22 +166,23 @@ public class AvatarApp : IDisposable
 
         _imGui.Render();
 
-        // Render components to their respective Spout outputs
-        foreach ( var spoutGroup in _spoutComponents )
+        // Render components to their respective Spout outputs (if spout is enabled)
+        if ( _config.Value.SpoutConfigs?.Enabled == true )
         {
-            var spoutTarget = spoutGroup.Key;
-            var components  = spoutGroup.Value;
-
-            // Begin frame for this spout target
-            _spoutRegistry.BeginFrame(spoutTarget);
-
-            // Render all components for this spout target
-            foreach ( var component in components )
+            foreach ( var spoutGroup in _spoutComponents )
             {
-                component.Render((float)deltaTime);
-            }
+                var spoutTarget = spoutGroup.Key;
+                var components = spoutGroup.Value;
 
-            _spoutRegistry.SendFrame(spoutTarget);
+                _spoutRegistry.BeginFrame(spoutTarget);
+            
+                foreach ( var component in components )
+                {
+                    component.Render((float)deltaTime);
+                }
+
+                _spoutRegistry.SendFrame(spoutTarget);
+            }
         }
     }
 

--- a/src/PersonaEngine/PersonaEngine.Lib/Live2D/NullLive2DComponent.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/Live2D/NullLive2DComponent.cs
@@ -1,0 +1,24 @@
+using PersonaEngine.Lib.UI;
+using Silk.NET.Input;
+using Silk.NET.OpenGL;
+using Silk.NET.Windowing;
+
+namespace PersonaEngine.Lib.Live2D;
+
+public class NullLive2DComponent : IRenderComponent
+{
+    public int DrawOrder => 100;
+
+    public void Dispose() { }
+    public void Draw() { }
+    public void Initialize() { }
+    public void LoadContent() { }
+    public void UnloadContent() { }
+    public bool UseSpout { get; } = false;
+    public string SpoutTarget { get; } = string.Empty;
+    public int Priority { get; } = -1;
+    public void Update(float deltaTime) { }
+    public void Render(float deltaTime) { }
+    public void Resize() { }
+    public void Initialize(GL gl, IView view, IInputContext input) { }
+}

--- a/src/PersonaEngine/PersonaEngine.Lib/PersonaEngine.Lib.csproj
+++ b/src/PersonaEngine/PersonaEngine.Lib/PersonaEngine.Lib.csproj
@@ -40,6 +40,7 @@
         <PackageReference Include="Stateless" Version="5.17.0" />
         <PackageReference Include="System.Runtime.Caching" Version="9.0.2"/>
         <PackageReference Include="Whisper.net" Version="1.8.1" />
+        <PackageReference Include="Whisper.net.Runtime.Cuda.Linux" Version="1.8.1" />
         <PackageReference Include="Whisper.net.Runtime.Cuda.Windows" Version="1.8.1" />
         <PackageReference Include="OpenNLP" Version="1.3.5"/>
     </ItemGroup>

--- a/src/PersonaEngine/PersonaEngine.Lib/ServiceCollectionExtensions.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/ServiceCollectionExtensions.cs
@@ -156,9 +156,7 @@ public static class ServiceCollectionExtensions
                     break;
             }
         }
-        
 
-        services.AddSingleton<IMicrophone, MicrophoneInputPortAudioSource>();
         services.AddSingleton<IAwaitableAudioSource>(sp => sp.GetRequiredService<IMicrophone>());
 
         return services;

--- a/src/PersonaEngine/PersonaEngine.Lib/ServiceCollectionExtensions.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/ServiceCollectionExtensions.cs
@@ -96,6 +96,8 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddASRSystem(this IServiceCollection services, IConfiguration configuration)
     {
+        MicrophoneConfiguration? microphoneOptions = configuration.GetSection("Config:Microphone").Get<MicrophoneConfiguration>();
+        
         services.Configure<AsrConfiguration>(configuration.GetSection("Config:Asr"));
         services.Configure<MicrophoneConfiguration>(configuration.GetSection("Config:Microphone"));
 
@@ -135,7 +137,28 @@ public static class ServiceCollectionExtensions
                                                                                                sp.GetRequiredService<ILogger<RealtimeTranscriptor>>());
                                                            });
 
-        services.AddSingleton<IMicrophone, MicrophoneInputNAudioSource>();
+        // If the configuration is missing, use the "default" engine: NAudio
+        if (microphoneOptions == null || microphoneOptions.InputEngine == null)
+        {
+            services.AddSingleton<IMicrophone, MicrophoneInputNAudioSource>();
+        }
+        else
+        {
+            switch (microphoneOptions.InputEngine.ToLower())
+            {
+                // better engine
+                case "naudio":
+                    services.AddSingleton<IMicrophone, MicrophoneInputNAudioSource>();
+                    break;
+                // engine with linux support
+                case "portaudio":
+                    services.AddSingleton<IMicrophone, MicrophoneInputPortAudioSource>();
+                    break;
+            }
+        }
+        
+
+        services.AddSingleton<IMicrophone, MicrophoneInputPortAudioSource>();
         services.AddSingleton<IAwaitableAudioSource>(sp => sp.GetRequiredService<IMicrophone>());
 
         return services;
@@ -274,10 +297,21 @@ public static class ServiceCollectionExtensions
     {
         services.Configure<Live2DOptions>(configuration.GetSection("Config:Live2D"));
 
-        services.AddSingleton<IRenderComponent, Live2DManager>();
-        services.AddSingleton<ILive2DAnimationService, VBridgerLipSyncService>();
-        services.AddSingleton<ILive2DAnimationService, IdleBlinkingAnimationService>();
-        services.AddEmotionProcessing(configuration);
+        // Get the config to check if Live2D is enabled
+        var live2dOptions = configuration.GetSection("Config:Live2D").Get<Live2DOptions>() ?? new Live2DOptions();
+        
+        if (live2dOptions.Enabled)
+        {
+            services.AddSingleton<IRenderComponent, Live2DManager>();
+            services.AddSingleton<ILive2DAnimationService, VBridgerLipSyncService>();
+            services.AddSingleton<ILive2DAnimationService, IdleBlinkingAnimationService>();
+            services.AddEmotionProcessing(configuration);
+        }
+        else
+        {
+            // Register dummy/no-op implementation when disabled
+            services.AddSingleton<IRenderComponent, NullLive2DComponent>();
+        }
 
         return services;
     }

--- a/src/PersonaEngine/PersonaEngine.Lib/UI/FontProvider.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/UI/FontProvider.cs
@@ -20,9 +20,9 @@ namespace PersonaEngine.Lib.UI;
 /// </summary>
 public class FontProvider : IStartupTask
 {
-    private const string FONTS_DIR = @"Resources\Fonts";
+    private static readonly string _fontsPath = Path.Combine("Resources", "Fonts");
 
-    private const string IMAGES_PATH = @"Resources\Imgs";
+    private static readonly string _imagesPath = Path.Combine("Resources", "Imgs");
 
     private readonly Dictionary<string, FontSystem> _fontCache = new();
 
@@ -45,14 +45,14 @@ public class FontProvider : IStartupTask
     {
         try
         {
-            if ( !Directory.Exists(FONTS_DIR) )
+            if ( !Directory.Exists(_fontsPath) )
             {
-                _logger.LogWarning("Fonts directory not found: {Path}", FONTS_DIR);
+                _logger.LogWarning("Fonts directory not found: {Path}", _fontsPath);
 
                 return Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
             }
 
-            var fontFiles = Directory.GetFiles(FONTS_DIR, "*.ttf");
+            var fontFiles = Directory.GetFiles(_fontsPath, "*.ttf");
             var fontNames = new List<string>(fontFiles.Length);
             foreach ( var file in fontFiles )
             {
@@ -77,7 +77,7 @@ public class FontProvider : IStartupTask
         if ( !_fontCache.TryGetValue(fontName, out var fontSystem) )
         {
             fontSystem = new FontSystem();
-            var fontData = File.ReadAllBytes(Path.Combine(FONTS_DIR, fontName));
+            var fontData = File.ReadAllBytes(Path.Combine(_fontsPath, fontName));
             fontSystem.AddFont(fontData);
             _fontCache[fontName] = fontSystem;
         }
@@ -89,7 +89,7 @@ public class FontProvider : IStartupTask
     {
         if ( !_textureCache.TryGetValue(imageName, out var texture) )
         {
-            using var stream      = File.OpenRead(Path.Combine(IMAGES_PATH, imageName));
+            using var stream      = File.OpenRead(Path.Combine(_imagesPath, imageName));
             var       imageResult = ImageResult.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
 
             // Premultiply alpha

--- a/src/PersonaEngine/PersonaEngine.Lib/UI/Spout/NullSpoutRegistry.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/UI/Spout/NullSpoutRegistry.cs
@@ -1,0 +1,14 @@
+using PersonaEngine.Lib.Configuration;
+
+namespace PersonaEngine.Lib.UI.Spout;
+
+public class NullSpoutRegistry : SpoutRegistry
+{
+    public NullSpoutRegistry() : base(null, new SpoutConfiguration { Enabled = false }) { }
+
+    public override void BeginFrame(string spoutName) { }
+    public override void SendFrame(string spoutName) { }
+    public override void ResizeAll(int width, int height) { }
+    public override void Dispose() { }
+    public override SpoutManager GetOrCreateManager(SpoutOutputConfigurations config) => null;
+}

--- a/src/PersonaEngine/PersonaEngine.Lib/UI/Spout/SpoutManager.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/UI/Spout/SpoutManager.cs
@@ -11,7 +11,7 @@ namespace PersonaEngine.Lib.UI.Spout;
 /// </summary>
 public class SpoutManager : IDisposable
 {
-    private readonly SpoutConfiguration _config;
+    private readonly SpoutOutputConfigurations _config;
 
     private readonly GL _gl;
 
@@ -25,7 +25,7 @@ public class SpoutManager : IDisposable
 
     private uint _depthAttachment;
 
-    public SpoutManager(GL gl, SpoutConfiguration config)
+    public SpoutManager(GL gl, SpoutOutputConfigurations config)
     {
         _gl          = gl;
         _config      = config;
@@ -33,10 +33,10 @@ public class SpoutManager : IDisposable
 
         InitializeCustomFramebuffer();
 
-        if ( !_spoutSender.CreateSender(config.OutputName, (uint)_config.Width, (uint)_config.Height, 0) )
+        if ( !_spoutSender.CreateSender(config.Name, (uint)_config.Width, (uint)_config.Height, 0) )
         {
             _spoutSender.Dispose();
-            Console.WriteLine($"Failed to create Spout Sender '{config.OutputName}'.");
+            Console.WriteLine($"Failed to create Spout Sender '{config.Name}'.");
         }
     }
 

--- a/src/PersonaEngine/PersonaEngine.Lib/UI/Spout/SpoutRegistry.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/UI/Spout/SpoutRegistry.cs
@@ -6,24 +6,24 @@ namespace PersonaEngine.Lib.UI.Spout;
 
 public class SpoutRegistry : IDisposable
 {
-    private readonly SpoutConfiguration[] _configs;
+    private readonly SpoutConfiguration _configs;
 
     private readonly GL _gl;
 
     private readonly Dictionary<string, SpoutManager> _spoutManagers = new();
 
-    public SpoutRegistry(GL gl, SpoutConfiguration[] configs)
+    public SpoutRegistry(GL gl, SpoutConfiguration configs)
     {
         _gl      = gl;
         _configs = configs;
 
-        foreach ( var config in _configs )
+        foreach ( var config in _configs.Outputs )
         {
             GetOrCreateManager(config);
         }
     }
 
-    public void Dispose()
+    public virtual void Dispose()
     {
         foreach ( var manager in _spoutManagers.Values )
         {
@@ -33,18 +33,18 @@ public class SpoutRegistry : IDisposable
         _spoutManagers.Clear();
     }
 
-    public SpoutManager GetOrCreateManager(SpoutConfiguration config)
+    public virtual SpoutManager GetOrCreateManager(SpoutOutputConfigurations config)
     {
-        if ( !_spoutManagers.TryGetValue(config.OutputName, out var manager) )
+        if ( !_spoutManagers.TryGetValue(config.Name, out var manager) )
         {
             manager = new SpoutManager(_gl, config);
-            _spoutManagers.Add(config.OutputName, manager);
+            _spoutManagers.Add(config.Name, manager);
         }
 
         return manager;
     }
 
-    public void BeginFrame(string spoutName)
+    public virtual void BeginFrame(string spoutName)
     {
         if ( string.IsNullOrEmpty(spoutName) || !_spoutManagers.TryGetValue(spoutName, out var manager) )
         {
@@ -54,7 +54,7 @@ public class SpoutRegistry : IDisposable
         manager.BeginFrame();
     }
 
-    public void SendFrame(string spoutName)
+    public virtual void SendFrame(string spoutName)
     {
         if ( string.IsNullOrEmpty(spoutName) || !_spoutManagers.TryGetValue(spoutName, out var manager) )
         {
@@ -64,7 +64,7 @@ public class SpoutRegistry : IDisposable
         manager.SendFrame();
     }
 
-    public void ResizeAll(int width, int height)
+    public virtual void ResizeAll(int width, int height)
     {
         foreach ( var manager in _spoutManagers.Values )
         {


### PR DESCRIPTION
Added linux support by making Live2D and Spout optional through the appsettings.json
Disabling them will change the DI to use "Null" alternatives that implement the methods but do not actually do anything. This currently works as both Live2DComponent and SpoutRegistry do not return any critical values.
Furthermore I added another appsettings option to choose the Audio Engine/IMicrophone and IAwaitableAudioSource service. This is required as NAudio is missing linux support and PortAudio has to be used as a fallback.
Another minor fix was how path's were currently handled. They now use the Path.Combine method.