### PR TITLE
fix(LLM): register vision engine with VisionModel + strip <think> tags

### DIFF
--- a/src/PersonaEngine/PersonaEngine.Lib/LLM/VisualQASemanticKernelChatEngine.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/LLM/VisualQASemanticKernelChatEngine.cs
@@ -51,6 +51,7 @@ public class VisualQASemanticKernelChatEngine : IVisualChatEngine
             ]);
 
             var chunkCount = 0;
+            var inThinkBlock = false;
 
             var streamingResponse = _chatCompletionService.GetStreamingChatMessageContentsAsync(
                                                                                                 chatHistory,
@@ -64,8 +65,10 @@ public class VisualQASemanticKernelChatEngine : IVisualChatEngine
 
                 chunkCount++;
                 var content = chunk.Content ?? string.Empty;
+                var filtered = StripThinkTags(content, ref inThinkBlock);
+                if ( filtered.Length == 0 ) continue;
 
-                yield return content;
+                yield return filtered;
             }
 
             _logger.LogInformation("Visual QA response streaming completed. Total chunks: {ChunkCount}", chunkCount);
@@ -74,5 +77,36 @@ public class VisualQASemanticKernelChatEngine : IVisualChatEngine
         {
             _semaphore.Release();
         }
+    }
+
+    private static string StripThinkTags(string input, ref bool inThinkBlock)
+    {
+        if ( input.Length == 0 ) return input;
+
+        var output = new System.Text.StringBuilder(input.Length);
+        var i = 0;
+        while ( i < input.Length )
+        {
+            if ( inThinkBlock )
+            {
+                var close = input.IndexOf("</think>", i, StringComparison.OrdinalIgnoreCase);
+                if ( close < 0 ) return output.ToString();
+                i = close + "</think>".Length;
+                inThinkBlock = false;
+            }
+            else
+            {
+                var open = input.IndexOf("<think>", i, StringComparison.OrdinalIgnoreCase);
+                if ( open < 0 )
+                {
+                    output.Append(input, i, input.Length - i);
+                    return output.ToString();
+                }
+                output.Append(input, i, open - i);
+                i = open + "<think>".Length;
+                inThinkBlock = true;
+            }
+        }
+        return output.ToString();
     }
 }

--- a/src/PersonaEngine/PersonaEngine.Lib/ServiceCollectionExtensions.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/ServiceCollectionExtensions.cs
@@ -173,7 +173,7 @@ public static class ServiceCollectionExtensions
                                   var kernelBuilder = Kernel.CreateBuilder();
 
                                   kernelBuilder.AddOpenAIChatCompletion(llmOptions.TextModel, new Uri(llmOptions.TextEndpoint), llmOptions.TextApiKey, serviceId: "text");
-                                  kernelBuilder.AddOpenAIChatCompletion(llmOptions.VisionEndpoint, new Uri(llmOptions.VisionEndpoint), llmOptions.VisionApiKey, serviceId: "vision");
+                                  kernelBuilder.AddOpenAIChatCompletion(llmOptions.VisionModel, new Uri(llmOptions.VisionEndpoint), llmOptions.VisionApiKey, serviceId: "vision");
 
                                   configureKernel?.Invoke(kernelBuilder);
 


### PR DESCRIPTION
## Summary
- `VisualQASemanticKernelChatEngine` was registered with `VisionEndpoint` as the model name (copy/paste from the text registration), so vision calls always hit a model named after the URL. This PR passes `VisionModel` through instead.
- Adds `<think>…</think>` stripping to the vision response path so reasoning-style models (e.g. `gemma3`/`gemma4`, `qwen3-vl`) surface the visible caption in `message.content` rather than an empty string.

## Files
- `PersonaEngine.Lib/LLM/VisualQASemanticKernelChatEngine.cs`
- `PersonaEngine.Lib/ServiceCollectionExtensions.cs`

## Test plan
- [ ] Configure `VisionModel` to a thinking-capable model and verify captions return non-empty.
- [ ] Confirm non-thinking vision models (e.g. `llava`) still work unchanged.