### PR TITLE
feat(events): add TextSegmentSubmitted input event

### DIFF
--- a/src/PersonaEngine/PersonaEngine.Lib/Core/Conversation/Abstractions/Session/ConversationTrigger.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/Core/Conversation/Abstractions/Session/ConversationTrigger.cs
@@ -35,6 +35,8 @@ public enum ConversationTrigger
     AudioStreamStarted,
     
     AudioStreamEnded,
-    
+
     ErrorOccurred,
+
+    InterruptRequested,
 }

--- a/src/PersonaEngine/PersonaEngine.Lib/Core/Conversation/Abstractions/Session/IConversationOrchestrator.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/Core/Conversation/Abstractions/Session/IConversationOrchestrator.cs
@@ -11,6 +11,8 @@ public interface IConversationOrchestrator : IAsyncDisposable
     IEnumerable<Guid> GetActiveSessionIds();
 
     ValueTask StopAllSessionsAsync();
+
+    ValueTask<bool> CancelPendingTurnAsync(Guid sessionId);
     
     event EventHandler? SessionsUpdated;
 }

--- a/src/PersonaEngine/PersonaEngine.Lib/Core/Conversation/Abstractions/Session/IConversationSession.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/Core/Conversation/Abstractions/Session/IConversationSession.cs
@@ -11,4 +11,6 @@ public interface IConversationSession : IAsyncDisposable
     ValueTask RunAsync(CancellationToken cancellationToken);
 
     ValueTask StopAsync();
+
+    ValueTask CancelPendingTurnAsync();
 }

--- a/src/PersonaEngine/PersonaEngine.Lib/Core/Conversation/Implementations/Events/Input/TextSegmentSubmitted.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/Core/Conversation/Implementations/Events/Input/TextSegmentSubmitted.cs
@@ -1,0 +1,19 @@
+using PersonaEngine.Lib.Core.Conversation.Abstractions.Events;
+
+namespace PersonaEngine.Lib.Core.Conversation.Implementations.Events.Input;
+
+/// <summary>
+/// A user-submitted text utterance that bypasses the speech pipeline.
+/// Treated by the orchestrator as a completed finalized input, equivalent
+/// in semantics to <see cref="SttSegmentRecognized"/> but without the
+/// STT-specific fields (duration, confidence).
+/// </summary>
+public record TextSegmentSubmitted(
+    Guid           SessionId,
+    DateTimeOffset Timestamp,
+    string         ParticipantId,
+    string         Text
+) : IInputEvent
+{
+    public Guid? TurnId { get; } = null;
+}

--- a/src/PersonaEngine/PersonaEngine.Lib/Core/Conversation/Implementations/Session/ConfigureStateMachine.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/Core/Conversation/Implementations/Session/ConfigureStateMachine.cs
@@ -38,9 +38,11 @@ public partial class ConversationSession
 
         _stateMachine.Configure(ConversationState.Idle)
                      .OnEntry(HandleIdle, "Handle Idle State")
+                     .OnEntryFromAsync(ConversationTrigger.InterruptRequested, CancelCurrentTurnProcessingAsync, "Cancel on External Interrupt")
                      .Ignore(ConversationTrigger.LlmStreamEnded)
                      .Ignore(ConversationTrigger.TtsStreamEnded)
                      .Ignore(ConversationTrigger.AudioStreamEnded)
+                     .Ignore(ConversationTrigger.InterruptRequested)
                      .Permit(ConversationTrigger.InputDetected, ConversationState.Listening)
                      .Permit(ConversationTrigger.InputFinalized, ConversationState.ProcessingInput)
                      .Permit(ConversationTrigger.StopRequested, ConversationState.Ended)
@@ -58,7 +60,8 @@ public partial class ConversationSession
                      .PermitIf(_inputDetectedTrigger, ConversationState.Interrupted,
                                ShouldAllowBargeIn, "Barge-In")
                      .PermitIf(_inputFinalizedTrigger, ConversationState.Interrupted,
-                               ShouldAllowBargeIn, "Barge-In");
+                               ShouldAllowBargeIn, "Barge-In")
+                     .Permit(ConversationTrigger.InterruptRequested, ConversationState.Idle);
 
         _stateMachine.Configure(ConversationState.ProcessingInput)
                      .SubstateOf(ConversationState.ActiveTurn)

--- a/src/PersonaEngine/PersonaEngine.Lib/Core/Conversation/Implementations/Session/ConversationOrchestrator.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/Core/Conversation/Implementations/Session/ConversationOrchestrator.cs
@@ -138,6 +138,26 @@ public class ConversationOrchestrator : IConversationOrchestrator
 
     public IEnumerable<Guid> GetActiveSessionIds() { return _activeSessions.Keys.ToList(); }
 
+    public async ValueTask<bool> CancelPendingTurnAsync(Guid sessionId)
+    {
+        if ( !_activeSessions.TryGetValue(sessionId, out var sessionInfo) )
+        {
+            _logger.LogWarning("Session {SessionId} not found for CancelPendingTurnAsync.", sessionId);
+            return false;
+        }
+
+        try
+        {
+            await sessionInfo.Session.CancelPendingTurnAsync();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error cancelling pending turn for session {SessionId}.", sessionId);
+            return false;
+        }
+    }
+
     public async ValueTask StopAllSessionsAsync()
     {
         if ( !_orchestratorCts.IsCancellationRequested )

--- a/src/PersonaEngine/PersonaEngine.Lib/Core/Conversation/Implementations/Session/ConversationSession.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/Core/Conversation/Implementations/Session/ConversationSession.cs
@@ -392,6 +392,7 @@ public partial class ConversationSession : IConversationSession
         return inputEvent switch {
             SttSegmentRecognizing ev => (ConversationTrigger.InputDetected, ev),
             SttSegmentRecognized ev => (ConversationTrigger.InputFinalized, ev),
+            TextSegmentSubmitted ev => (ConversationTrigger.InputFinalized, ev),
             _ => (null, null)
         };
     }
@@ -531,7 +532,14 @@ public partial class ConversationSession : IConversationSession
 
     private async Task PrepareLlmRequestAsync(IInputEvent inputEvent)
     {
-        if ( inputEvent is not SttSegmentRecognized finalizedEvent )
+        var finalText = inputEvent switch
+        {
+            SttSegmentRecognized stt => stt.FinalTranscript,
+            TextSegmentSubmitted txt => txt.Text,
+            _ => null
+        };
+
+        if ( finalText is null )
         {
             _logger.LogWarning("{SessionId} | PrepareLlmRequestAsync received unexpected event type: {EventType}", SessionId, inputEvent.GetType().Name);
             await FireErrorAsync(new ArgumentException("Invalid event type for InputFinalized trigger.", nameof(inputEvent)), false);
@@ -539,7 +547,7 @@ public partial class ConversationSession : IConversationSession
             return;
         }
 
-        _logger.LogDebug("{SessionId} | Action: PrepareLlmRequestAsync for input: \"{InputText}\"", SessionId, finalizedEvent.FinalTranscript);
+        _logger.LogDebug("{SessionId} | Action: PrepareLlmRequestAsync for input: \"{InputText}\"", SessionId, finalText);
 
         // In-case race condition (channel events not consumed fast enough)
         await CancelCurrentTurnProcessingAsync();
@@ -560,13 +568,13 @@ public partial class ConversationSession : IConversationSession
 
         try
         {
-            _context.StartTurn(_currentTurnId.Value, [finalizedEvent.ParticipantId, ASSISTANT_PARTICIPANT.Id]);
-            _context.AppendToTurn(finalizedEvent.ParticipantId, finalizedEvent.FinalTranscript);
+            _context.StartTurn(_currentTurnId.Value, [inputEvent.ParticipantId, ASSISTANT_PARTICIPANT.Id]);
+            _context.AppendToTurn(inputEvent.ParticipantId, finalText);
 
-            var userName = _context.Participants.TryGetValue(finalizedEvent.ParticipantId, out var pInfo) ? pInfo.Name : finalizedEvent.ParticipantId;
-            _logger.LogInformation("{SessionId} | {TurnId} | 📝 | [{Speaker}]{Text}", SessionId, _currentTurnId, userName, _context.GetPendingMessageText(finalizedEvent.ParticipantId));
+            var userName = _context.Participants.TryGetValue(inputEvent.ParticipantId, out var pInfo) ? pInfo.Name : inputEvent.ParticipantId;
+            _logger.LogInformation("{SessionId} | {TurnId} | 📝 | [{Speaker}]{Text}", SessionId, _currentTurnId, userName, _context.GetPendingMessageText(inputEvent.ParticipantId));
 
-            _context.CompleteTurnPart(finalizedEvent.ParticipantId);
+            _context.CompleteTurnPart(inputEvent.ParticipantId);
 
             await _stateMachine.FireAsync(ConversationTrigger.LlmRequestSent);
 

--- a/src/PersonaEngine/PersonaEngine.Lib/Core/Conversation/Implementations/Session/ConversationSession.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/Core/Conversation/Implementations/Session/ConversationSession.cs
@@ -158,6 +158,21 @@ public partial class ConversationSession : IConversationSession
         }
     }
 
+    public async ValueTask CancelPendingTurnAsync()
+    {
+        if ( _isDisposed )
+        {
+            return;
+        }
+
+        _logger.LogInformation("{SessionId} | CancelPendingTurnAsync called. Current State: {State}", SessionId, _stateMachine.State);
+
+        if ( _stateMachine.CanFire(ConversationTrigger.InterruptRequested) )
+        {
+            await _stateMachine.FireAsync(ConversationTrigger.InterruptRequested);
+        }
+    }
+
     #region Event Processing Loops
 
     private async Task ProcessInputEventsAsync(CancellationToken cancellationToken)

--- a/src/PersonaEngine/PersonaEngine.Lib/LLM/VisualQASemanticKernelChatEngine.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/LLM/VisualQASemanticKernelChatEngine.cs
@@ -51,6 +51,7 @@ public class VisualQASemanticKernelChatEngine : IVisualChatEngine
             ]);
 
             var chunkCount = 0;
+            var inThinkBlock = false;
 
             var streamingResponse = _chatCompletionService.GetStreamingChatMessageContentsAsync(
                                                                                                 chatHistory,
@@ -64,8 +65,10 @@ public class VisualQASemanticKernelChatEngine : IVisualChatEngine
 
                 chunkCount++;
                 var content = chunk.Content ?? string.Empty;
+                var filtered = StripThinkTags(content, ref inThinkBlock);
+                if ( filtered.Length == 0 ) continue;
 
-                yield return content;
+                yield return filtered;
             }
 
             _logger.LogInformation("Visual QA response streaming completed. Total chunks: {ChunkCount}", chunkCount);
@@ -74,5 +77,36 @@ public class VisualQASemanticKernelChatEngine : IVisualChatEngine
         {
             _semaphore.Release();
         }
+    }
+
+    private static string StripThinkTags(string input, ref bool inThinkBlock)
+    {
+        if ( input.Length == 0 ) return input;
+
+        var output = new System.Text.StringBuilder(input.Length);
+        var i = 0;
+        while ( i < input.Length )
+        {
+            if ( inThinkBlock )
+            {
+                var close = input.IndexOf("</think>", i, StringComparison.OrdinalIgnoreCase);
+                if ( close < 0 ) return output.ToString();
+                i = close + "</think>".Length;
+                inThinkBlock = false;
+            }
+            else
+            {
+                var open = input.IndexOf("<think>", i, StringComparison.OrdinalIgnoreCase);
+                if ( open < 0 )
+                {
+                    output.Append(input, i, input.Length - i);
+                    return output.ToString();
+                }
+                output.Append(input, i, open - i);
+                i = open + "<think>".Length;
+                inThinkBlock = true;
+            }
+        }
+        return output.ToString();
     }
 }

--- a/src/PersonaEngine/PersonaEngine.Lib/ServiceCollectionExtensions.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/ServiceCollectionExtensions.cs
@@ -173,7 +173,7 @@ public static class ServiceCollectionExtensions
                                   var kernelBuilder = Kernel.CreateBuilder();
 
                                   kernelBuilder.AddOpenAIChatCompletion(llmOptions.TextModel, new Uri(llmOptions.TextEndpoint), llmOptions.TextApiKey, serviceId: "text");
-                                  kernelBuilder.AddOpenAIChatCompletion(llmOptions.VisionEndpoint, new Uri(llmOptions.VisionEndpoint), llmOptions.VisionApiKey, serviceId: "vision");
+                                  kernelBuilder.AddOpenAIChatCompletion(llmOptions.VisionModel, new Uri(llmOptions.VisionEndpoint), llmOptions.VisionApiKey, serviceId: "vision");
 
                                   configureKernel?.Invoke(kernelBuilder);
 


### PR DESCRIPTION
## Summary
Introduces a first-class `TextSegmentSubmitted` input event so text-based input adapters can submit user turns without masquerading as a fake `SttSegmentRecognized`. `ConversationSession` now handles both event types on the same code path.

- New `Events/Input/TextSegmentSubmitted` event type.
- `ConversationSession` routes text and STT submissions through a shared handler.

## Motivation
Downstream integrations (e.g. web UIs that accept typed chat) were forced to fabricate ASR segments, which polluted telemetry and made it impossible to distinguish text from voice. This gives them a clean seam.

## Dependencies
Stacked on #17 + #18. The branch's own commit is the single `feat(events)` commit.

## Files
- `Core/Conversation/Abstractions/Events/Input/TextSegmentSubmitted.cs`
- `Core/Conversation/Implementations/Session/ConversationSession.cs`

## Test plan
- [ ] Submit a `TextSegmentSubmitted` and verify it produces an assistant turn identical to an STT-driven one.
- [ ] Confirm existing mic/Whisper flow is unchanged.