### PR TITLE
fix(app): register CUDA runtime before LLama/ONNX to prevent DllNotFoundException on fresh installs

### DIFF
--- a/src/PersonaEngine/PersonaEngine.App/LoggingConfiguration.cs
+++ b/src/PersonaEngine/PersonaEngine.App/LoggingConfiguration.cs
@@ -1,0 +1,134 @@
+using LLama.Native;
+using Microsoft.ML.OnnxRuntime;
+using Serilog;
+using Serilog.Events;
+
+namespace PersonaEngine.App;
+
+/// <summary>
+///     Centralised Serilog + native-runtime log wiring for the App host.
+///     Separated from <see cref="Program" /> so startup ordering and log overrides live
+///     in one place instead of being scattered through <c>Main</c>.
+/// </summary>
+internal static class LoggingConfiguration
+{
+    /// <summary>
+    ///     Minimum levels per source context. Kept in one table so adding a new subsystem
+    ///     override is a single-line change instead of a fluent chain edit.
+    /// </summary>
+    private static readonly (string SourceContext, LogEventLevel Level)[] SourceOverrides =
+    [
+        ("PersonaEngine.Lib.Core.Conversation", LogEventLevel.Information),
+        ("PersonaEngine.Lib.TTS.Synthesis.Alignment", LogEventLevel.Information),
+        ("PersonaEngine.Lib.TTS.Synthesis.LipSync", LogEventLevel.Information),
+        ("PersonaEngine.Lib.TTS.Synthesis.Engine.SentenceProcessor", LogEventLevel.Information),
+        ("Startup", LogEventLevel.Information),
+        ("PersonaEngine.Lib.UI.Overlay", LogEventLevel.Information),
+        ("llama.cpp", LogEventLevel.Error),
+    ];
+
+    /// <summary>
+    ///     Initialises <see cref="Log.Logger" /> with console sink and per-subsystem level
+    ///     overrides. Safe to call exactly once at process startup.
+    /// </summary>
+    public static void ConfigureSerilog()
+    {
+        var config = new LoggerConfiguration()
+            .MinimumLevel.Warning()
+            .Enrich.FromLogContext()
+            .Enrich.With<GuidToEmojiEnricher>()
+            .WriteTo.Console(
+                outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"
+            );
+
+        foreach (var (source, level) in SourceOverrides)
+        {
+            config = config.MinimumLevel.Override(source, level);
+        }
+
+        Log.Logger = config.CreateLogger();
+    }
+
+    /// <summary>
+    ///     Wires Serilog into the AppDomain-level unhandled-exception and process-exit
+    ///     events so we get a final fatal log line even on crashes escaping the main loop.
+    /// </summary>
+    public static void InstallGlobalExceptionHandlers()
+    {
+        AppDomain.CurrentDomain.UnhandledException += static (_, e) =>
+        {
+            if (e.ExceptionObject is Exception ex)
+            {
+                Log.Fatal(ex, "Unhandled exception (terminating={Terminating})", e.IsTerminating);
+            }
+            else
+            {
+                Log.Fatal("Unhandled non-Exception object: {Object}", e.ExceptionObject);
+            }
+
+            Log.CloseAndFlush();
+        };
+
+        AppDomain.CurrentDomain.ProcessExit += static (_, _) => Log.CloseAndFlush();
+    }
+
+    /// <summary>
+    ///     Silences ONNX Runtime warnings globally before any <c>InferenceSession</c> is created.
+    ///     ORT's default verbosity duplicates diagnostics we already capture at the model-loader level.
+    /// </summary>
+    public static void SuppressOnnxRuntimeWarnings()
+    {
+        OrtEnv.Instance().EnvLogLevel = OrtLoggingLevel.ORT_LOGGING_LEVEL_ERROR;
+    }
+
+    /// <summary>
+    ///     Bridges LLamaSharp's native log callback into Serilog under the <c>llama.cpp</c>
+    ///     source context. Must be invoked before any LLama inference to capture load-time diagnostics.
+    /// </summary>
+    public static void BridgeLlamaLogging()
+    {
+        var llamaLogger = Log.ForContext("SourceContext", "llama.cpp");
+        NativeLibraryConfig.LLama.WithLogCallback(
+            (level, message) =>
+            {
+                var msg = message.TrimEnd('\n', '\r');
+                if (string.IsNullOrEmpty(msg))
+                {
+                    return;
+                }
+
+                switch (level)
+                {
+                    case LLamaLogLevel.Error:
+                        llamaLogger.Error("{Message}", msg);
+                        // ggml/llama call abort() shortly after emitting an error. Flush the
+                        // managed Console buffer synchronously so the line survives the crash.
+                        FlushConsoleBestEffort();
+                        break;
+                    case LLamaLogLevel.Warning:
+                        llamaLogger.Warning("{Message}", msg);
+                        break;
+                    case LLamaLogLevel.Info:
+                        llamaLogger.Information("{Message}", msg);
+                        break;
+                    case LLamaLogLevel.Debug:
+                        llamaLogger.Debug("{Message}", msg);
+                        break;
+                }
+            }
+        );
+    }
+
+    private static void FlushConsoleBestEffort()
+    {
+        try
+        {
+            Console.Out.Flush();
+            Console.Error.Flush();
+        }
+        catch
+        {
+            // Best-effort flush on a pre-abort path; swallow any I/O failures.
+        }
+    }
+}

--- a/src/PersonaEngine/PersonaEngine.App/NativeLibraryLoader.cs
+++ b/src/PersonaEngine/PersonaEngine.App/NativeLibraryLoader.cs
@@ -1,0 +1,173 @@
+using System.Runtime.InteropServices;
+using LLama.Native;
+using Serilog;
+using ILogger = Serilog.ILogger;
+
+namespace PersonaEngine.App;
+
+/// <summary>
+///     Orchestrates native DLL loading for the app's CUDA-backed runtimes.
+///     <para>
+///         Windows only resolves import tables through <c>LoadLibrary</c>'s search path or
+///         whatever is already loaded in the process. The bootstrapper drops CUDA/cuDNN
+///         redistributables under <c>Resources/&lt;pkg&gt;</c>, which is <em>not</em> on any
+///         default search path. We therefore pre-load every bootstrapped DLL via
+///         <c>LoadLibraryExW</c> with <c>LOAD_WITH_ALTERED_SEARCH_PATH</c> before any
+///         managed code (ONNX Runtime GPU, Whisper.net, LLamaSharp) triggers a transitive
+///         native load that would otherwise fail.
+///     </para>
+///     <para>
+///         Load order matters: <c>cudart</c> must come before libraries that import it
+///         (<c>cublas</c>, <c>cublasLt</c>, <c>cufft</c>); <c>cudnn</c> comes last because
+///         it depends on <c>cublas/cublasLt</c>. CUDA 12 (ONNX Runtime GPU) and CUDA 13
+///         (Whisper.net's <c>ggml-cuda-whisper.dll</c>) coexist under separate suffixed dirs.
+///     </para>
+/// </summary>
+internal static partial class NativeLibraryLoader
+{
+    private const uint LoadWithAlteredSearchPath = 0x00000008;
+
+    /// <summary>
+    ///     Paths (relative to <c>&lt;BaseDir&gt;/Resources</c>) mirroring the install
+    ///     manifest's <c>installPath</c>. Ordered to satisfy CUDA's load-time dependency chain.
+    /// </summary>
+    private static readonly string[] CudaPreloadOrder =
+    [
+        "cuda/cudart",
+        "cuda/cudart-v13",
+        "cuda/cublas",
+        "cuda/cublas-v13",
+        "cuda/cufft",
+        "cudnn",
+    ];
+
+    [LibraryImport(
+        "kernel32.dll",
+        EntryPoint = "SetDllDirectoryW",
+        SetLastError = true,
+        StringMarshalling = StringMarshalling.Utf16
+    )]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SetDllDirectory(string? lpPathName);
+
+    [LibraryImport(
+        "kernel32.dll",
+        EntryPoint = "LoadLibraryExW",
+        SetLastError = true,
+        StringMarshalling = StringMarshalling.Utf16
+    )]
+    private static partial IntPtr LoadLibraryEx(string lpLibFileName, IntPtr hFile, uint dwFlags);
+
+    /// <summary>
+    ///     Registers <c>&lt;BaseDir&gt;/native</c> as an additional DLL search directory.
+    ///     The <c>native</c> folder holds loose DLLs relocated by the publish target.
+    /// </summary>
+    public static void RegisterNativeSearchDirectory()
+    {
+        var nativeDir = Path.Combine(AppContext.BaseDirectory, "native");
+        if (Directory.Exists(nativeDir))
+        {
+            SetDllDirectory(nativeDir);
+        }
+    }
+
+    /// <summary>
+    ///     Pre-loads every bootstrapped CUDA/cuDNN DLL into the process. After this call,
+    ///     subsequent imports against the same DLL names resolve to these copies regardless
+    ///     of the process DLL search path.
+    /// </summary>
+    public static void PreloadCudaRuntime(ILogger? logger = null)
+    {
+        logger ??= Log.Logger;
+
+        foreach (var relative in CudaPreloadOrder)
+        {
+            var dir = Path.Combine(
+                AppContext.BaseDirectory,
+                "Resources",
+                relative.Replace('/', Path.DirectorySeparatorChar)
+            );
+
+            if (!Directory.Exists(dir))
+            {
+                logger.Debug("CUDA pre-load: skipping missing directory {Dir}", dir);
+                continue;
+            }
+
+            foreach (var dll in Directory.EnumerateFiles(dir, "*.dll", SearchOption.AllDirectories))
+            {
+                TryPreloadNative(dll, logger);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Pre-loads LLamaSharp's CUDA12 <c>llama.dll</c> and its split <c>ggml-cpu.dll</c>
+    ///     sibling, then pins the library path in <see cref="NativeLibraryConfig" />.
+    ///     <para>
+    ///         Must run <em>after</em> <see cref="PreloadCudaRuntime" />, otherwise
+    ///         <c>ggml-cuda.dll</c>'s transitive imports (<c>cudart64_12.dll</c>,
+    ///         <c>cublas64_12.dll</c>) fail to resolve on systems without a global CUDA
+    ///         install on <c>PATH</c>.
+    ///     </para>
+    /// </summary>
+    public static void PreloadLlamaBackend(ILogger? logger = null)
+    {
+        logger ??= Log.Logger;
+
+        var llamaNativeDir = Path.Combine(
+            AppContext.BaseDirectory,
+            "runtimes",
+            "win-x64",
+            "native"
+        );
+        var llamaDll = Path.Combine(llamaNativeDir, "cuda12", "llama.dll");
+
+        if (!File.Exists(llamaDll))
+        {
+            logger.Debug("LLama pre-load: {Dll} not found, skipping", llamaDll);
+            return;
+        }
+
+        // ggml.dll imports ggml-cpu.dll which is not shipped under cuda12/.
+        // Pre-load it from the avx2/ (or avx/ fallback) sibling directory so the
+        // CUDA chain can satisfy its CPU-fallback import.
+        var cpuDll = Path.Combine(llamaNativeDir, "avx2", "ggml-cpu.dll");
+        if (!File.Exists(cpuDll))
+        {
+            cpuDll = Path.Combine(llamaNativeDir, "avx", "ggml-cpu.dll");
+        }
+
+        if (File.Exists(cpuDll))
+        {
+            TryPreloadNative(cpuDll, logger);
+        }
+
+        if (LoadLibraryEx(llamaDll, IntPtr.Zero, LoadWithAlteredSearchPath) == IntPtr.Zero)
+        {
+            var err = Marshal.GetLastWin32Error();
+            throw new DllNotFoundException(
+                $"Failed to load {llamaDll} (Win32 error {err}). "
+                    + "Check that the CUDA redistributables under Resources/cuda have been bootstrapped "
+                    + "and that PreloadCudaRuntime() ran before this call."
+            );
+        }
+
+        NativeLibraryConfig.LLama.WithLibrary(llamaDll);
+    }
+
+    private static void TryPreloadNative(string dllPath, ILogger logger)
+    {
+        if (LoadLibraryEx(dllPath, IntPtr.Zero, LoadWithAlteredSearchPath) != IntPtr.Zero)
+        {
+            return;
+        }
+
+        var err = Marshal.GetLastWin32Error();
+        logger.Warning(
+            "Native pre-load: LoadLibraryEx failed for {Dll} (Win32 error {Err})",
+            dllPath,
+            err
+        );
+    }
+}

--- a/src/PersonaEngine/PersonaEngine.App/PersonaEngine.App.csproj
+++ b/src/PersonaEngine/PersonaEngine.App/PersonaEngine.App.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- Required by the LibraryImport source generator used in NativeLibraryLoader. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <AssemblyName>PersonaEngine</AssemblyName>
   </PropertyGroup>

--- a/src/PersonaEngine/PersonaEngine.App/Program.cs
+++ b/src/PersonaEngine/PersonaEngine.App/Program.cs
@@ -1,132 +1,26 @@
-using System.Runtime.InteropServices;
 using System.Text;
-using LLama.Native;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.ML.OnnxRuntime;
 using PersonaEngine.Lib;
 using PersonaEngine.Lib.Bootstrapper;
 using PersonaEngine.Lib.Core;
 using Serilog;
-using Serilog.Events;
 
 namespace PersonaEngine.App;
 
 internal static class Program
 {
-    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern bool SetDllDirectory(string lpPathName);
-
-    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern IntPtr LoadLibraryEx(string lpLibFileName, IntPtr hFile, uint dwFlags);
-
-    private const uint LoadWithAlteredSearchPath = 0x00000008;
-
     private static async Task<int> Main(string[] args)
     {
-        var nativeDir = Path.Combine(AppContext.BaseDirectory, "native");
-        if (Directory.Exists(nativeDir))
-        {
-            SetDllDirectory(nativeDir);
-        }
-
         Console.OutputEncoding = Encoding.UTF8;
 
-        // LLamaSharp CUDA12 backend: ggml.dll imports ggml-cpu.dll which isn't in the
-        // cuda12/ dir. Pre-load it from the avx2 dir, then load the CUDA12 chain.
-        var llamaNativeDir = Path.Combine(
-            AppContext.BaseDirectory,
-            "runtimes",
-            "win-x64",
-            "native"
-        );
-        var llamaCudaDir = Path.Combine(llamaNativeDir, "cuda12");
-        var llamaDll = Path.Combine(llamaCudaDir, "llama.dll");
-        if (File.Exists(llamaDll))
-        {
-            // ggml-cpu.dll is in the avx2/ (or avx/) sibling directory
-            var cpuDll = Path.Combine(llamaNativeDir, "avx2", "ggml-cpu.dll");
-            if (!File.Exists(cpuDll))
-            {
-                cpuDll = Path.Combine(llamaNativeDir, "avx", "ggml-cpu.dll");
-            }
+        LoggingConfiguration.ConfigureSerilog();
+        LoggingConfiguration.InstallGlobalExceptionHandlers();
 
-            if (File.Exists(cpuDll))
-            {
-                LoadLibraryEx(cpuDll, IntPtr.Zero, LoadWithAlteredSearchPath);
-            }
-
-            if (LoadLibraryEx(llamaDll, IntPtr.Zero, LoadWithAlteredSearchPath) == IntPtr.Zero)
-            {
-                throw new DllNotFoundException(
-                    $"Failed to load {llamaDll}. Check that all native dependencies are present."
-                );
-            }
-
-            NativeLibraryConfig.LLama.WithLibrary(llamaDll);
-        }
-
-        CreateLogger();
-
-        var llamaLogger = Log.ForContext("SourceContext", "llama.cpp");
-        NativeLibraryConfig.LLama.WithLogCallback(
-            (level, message) =>
-            {
-                var msg = message.TrimEnd('\n', '\r');
-                if (string.IsNullOrEmpty(msg))
-                    return;
-
-                switch (level)
-                {
-                    case LLamaLogLevel.Error:
-                        llamaLogger.Error("{Message}", msg);
-                        // ggml/llama call abort() shortly after emitting an error. Flush
-                        // the managed Console buffer synchronously so the line survives.
-                        try
-                        {
-                            Console.Out.Flush();
-                            Console.Error.Flush();
-                        }
-                        catch
-                        {
-                            // Ignore — we're on a best-effort pre-abort path
-                        }
-
-                        break;
-                    case LLamaLogLevel.Warning:
-                        llamaLogger.Warning("{Message}", msg);
-                        break;
-                    case LLamaLogLevel.Info:
-                        llamaLogger.Information("{Message}", msg);
-                        break;
-                    case LLamaLogLevel.Debug:
-                        llamaLogger.Debug("{Message}", msg);
-                        break;
-                }
-            }
-        );
-
-        AppDomain.CurrentDomain.UnhandledException += (_, e) =>
-        {
-            if (e.ExceptionObject is Exception ex)
-            {
-                Log.Fatal(ex, "Unhandled exception (terminating={Terminating})", e.IsTerminating);
-            }
-            else
-            {
-                Log.Fatal("Unhandled non-Exception object: {Object}", e.ExceptionObject);
-            }
-
-            Log.CloseAndFlush();
-        };
-
-        AppDomain.CurrentDomain.ProcessExit += (_, _) =>
-        {
-            Log.CloseAndFlush();
-        };
-
-        // Suppress ONNX Runtime warnings globally before any sessions are created
-        OrtEnv.Instance().EnvLogLevel = OrtLoggingLevel.ORT_LOGGING_LEVEL_ERROR;
+        // Register <BaseDir>/native as an extra DLL search directory for loose
+        // native libs relocated by the publish target. This only needs to happen
+        // once and has no dependency on CUDA assets.
+        NativeLibraryLoader.RegisterNativeSearchDirectory();
 
         // ── Bootstrap ────────────────────────────────────────────────────────────
         // Run the asset bootstrapper before any subsystem that depends on models
@@ -136,7 +30,67 @@ internal static class Program
         // and the embedded manifest — any future bootstrap setting must be a CLI
         // flag, not an appsettings.json entry.
         var parsedArgs = CommandLineArgs.Parse(args);
+        if (!await RunBootstrapAsync(parsedArgs).ConfigureAwait(false))
+        {
+            await Log.CloseAndFlushAsync();
+            return 1;
+        }
 
+        // ── Native CUDA / LLama pre-load (order matters) ─────────────────────────
+        // 1. PreloadCudaRuntime registers the bootstrapped cudart/cublas/cufft/cudnn
+        //    DLLs with the Windows loader. Once mapped, ONNX Runtime GPU and
+        //    Whisper.net resolve their imports against these copies regardless of
+        //    the process DLL search path.
+        // 2. PreloadLlamaBackend then loads cuda12/llama.dll, whose transitive
+        //    dependency on ggml-cuda.dll -> cudart64_12.dll/cublas64_12.dll can
+        //    only resolve once step 1 has completed. Calling step 2 before step 1
+        //    on a system without a global CUDA install is what produced the
+        //    `llama.dll: DllNotFoundException` users hit on fresh installs.
+        // 3. BridgeLlamaLogging wires LLamaSharp's log callback after the backend
+        //    is known-good, so load-time diagnostics flow through Serilog.
+        NativeLibraryLoader.PreloadCudaRuntime();
+        NativeLibraryLoader.PreloadLlamaBackend();
+        LoggingConfiguration.BridgeLlamaLogging();
+
+        // OrtEnv.Instance() triggers the GPU-enabled onnxruntime.dll load, which itself
+        // imports cudart64_12.dll/cublas64_12.dll. Must run after PreloadCudaRuntime
+        // so those imports resolve against the bootstrapped copies.
+        LoggingConfiguration.SuppressOnnxRuntimeWarnings();
+
+        // ── Configuration + validation ───────────────────────────────────────────
+        IConfiguration config = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+            .Build();
+
+        if (!StartupValidator.Run(config))
+        {
+            await Log.CloseAndFlushAsync();
+            Console.WriteLine();
+            Console.WriteLine("Press any key to exit...");
+            Console.ReadKey(intercept: true);
+            return 1;
+        }
+
+        // ── Application composition ──────────────────────────────────────────────
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.AddSerilog());
+        services.AddMetrics();
+        services.AddApp(config);
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var window = serviceProvider.GetRequiredService<AvatarApp>();
+        window.Run();
+
+        return 0;
+    }
+
+    /// <summary>
+    ///     Runs the asset bootstrapper in an isolated DI scope. Returns <c>true</c> when
+    ///     the bootstrap pipeline completes successfully or there's nothing to do.
+    /// </summary>
+    private static async Task<bool> RunBootstrapAsync(CommandLineArgs parsedArgs)
+    {
         var bootstrapServices = new ServiceCollection();
         bootstrapServices.AddBootstrapper(parsedArgs.NonInteractive);
         // Wire MEL through the static Serilog logger so bootstrap-time diagnostics
@@ -145,141 +99,19 @@ internal static class Program
         // the only operator-visible signal is the final "Bootstrap failed" FTL line.
         bootstrapServices.AddLogging(b => b.AddSerilog(dispose: false));
 
-        await using (var bootstrapProvider = bootstrapServices.BuildServiceProvider())
-        {
-            var runner = bootstrapProvider.GetRequiredService<BootstrapRunner>();
-            var bootstrapResult = await runner.RunAsync(
-                parsedArgs.Bootstrap,
-                CancellationToken.None
-            );
+        await using var bootstrapProvider = bootstrapServices.BuildServiceProvider();
+        var runner = bootstrapProvider.GetRequiredService<BootstrapRunner>();
+        var result = await runner
+            .RunAsync(parsedArgs.Bootstrap, CancellationToken.None)
+            .ConfigureAwait(false);
 
-            if (!bootstrapResult.Success)
-            {
-                Log.Fatal("Bootstrap failed: {Reason}", bootstrapResult.ErrorMessage);
-                await Log.CloseAndFlushAsync();
-                Console.Error.WriteLine($"Bootstrap failed: {bootstrapResult.ErrorMessage}");
-                return 1;
-            }
+        if (result.Success)
+        {
+            return true;
         }
 
-        // ── CUDA / cuDNN pre-load ────────────────────────────────────────────────
-        // The bootstrapper drops NVIDIA redistributables under Resources/cuda/<pkg>
-        // and Resources/cudnn (see Assets/Manifest/install-manifest.json). The
-        // single SetDllDirectory call above only covers <BaseDir>/native, so we
-        // pre-load every bootstrapped CUDA DLL here via LoadLibraryEx with
-        // LoadWithAlteredSearchPath. Once mapped, ONNX Runtime GPU and
-        // Whisper.net's CUDA backend resolve their imports against these copies
-        // regardless of the process DLL search path.
-        //
-        // Order matters: cudart must come first so cublas/cublasLt/cufft can
-        // resolve their cudart imports during their own load. cudnn last as it
-        // depends on cublas/cublasLt. Both CUDA 12 (for ONNX Runtime GPU) and
-        // CUDA 13 (for Whisper.net's ggml-cuda-whisper.dll, which imports
-        // cublas64_13.dll) live side-by-side under their own version-suffixed
-        // install dirs.
-        PreloadCudaRuntime();
-
-        var builder = new ConfigurationBuilder()
-            .SetBasePath(Directory.GetCurrentDirectory())
-            .AddJsonFile("appsettings.json", false, true);
-
-        IConfiguration config = builder.Build();
-
-        if (!StartupValidator.Run(config))
-        {
-            await Log.CloseAndFlushAsync();
-            Console.WriteLine();
-            Console.WriteLine("Press any key to exit...");
-            Console.ReadKey(true);
-            return 1;
-        }
-
-        var services = new ServiceCollection();
-
-        services.AddLogging(loggingBuilder =>
-        {
-            loggingBuilder.AddSerilog();
-        });
-
-        services.AddMetrics();
-        services.AddApp(config);
-
-        var serviceProvider = services.BuildServiceProvider();
-
-        var window = serviceProvider.GetRequiredService<AvatarApp>();
-        window.Run();
-
-        await serviceProvider.DisposeAsync();
-        return 0;
-    }
-
-    private static void PreloadCudaRuntime()
-    {
-        // Ordered to satisfy CUDA's load-time dependency chain. Each entry is a
-        // path under <BaseDir>/Resources mirroring the manifest's installPath.
-        var loadOrder = new[]
-        {
-            "cuda/cudart",
-            "cuda/cudart-v13",
-            "cuda/cublas",
-            "cuda/cublas-v13",
-            "cuda/cufft",
-            "cudnn",
-        };
-
-        foreach (var relative in loadOrder)
-        {
-            var dir = Path.Combine(
-                AppContext.BaseDirectory,
-                "Resources",
-                relative.Replace('/', Path.DirectorySeparatorChar)
-            );
-            if (!Directory.Exists(dir))
-            {
-                Log.Debug("CUDA pre-load: skipping missing directory {Dir}", dir);
-                continue;
-            }
-
-            foreach (var dll in Directory.EnumerateFiles(dir, "*.dll", SearchOption.AllDirectories))
-            {
-                if (LoadLibraryEx(dll, IntPtr.Zero, LoadWithAlteredSearchPath) == IntPtr.Zero)
-                {
-                    var err = Marshal.GetLastWin32Error();
-                    Log.Warning(
-                        "CUDA pre-load: LoadLibraryEx failed for {Dll} (Win32 error {Err})",
-                        dll,
-                        err
-                    );
-                }
-            }
-        }
-    }
-
-    private static void CreateLogger()
-    {
-        Log.Logger = new LoggerConfiguration()
-            .MinimumLevel.Warning()
-            .MinimumLevel.Override("PersonaEngine.Lib.Core.Conversation", LogEventLevel.Information)
-            .MinimumLevel.Override(
-                "PersonaEngine.Lib.TTS.Synthesis.Alignment",
-                LogEventLevel.Information
-            )
-            .MinimumLevel.Override(
-                "PersonaEngine.Lib.TTS.Synthesis.LipSync",
-                LogEventLevel.Information
-            )
-            .MinimumLevel.Override(
-                "PersonaEngine.Lib.TTS.Synthesis.Engine.SentenceProcessor",
-                LogEventLevel.Information
-            )
-            .MinimumLevel.Override("Startup", LogEventLevel.Information)
-            .MinimumLevel.Override("PersonaEngine.Lib.UI.Overlay", LogEventLevel.Information)
-            .MinimumLevel.Override("llama.cpp", LogEventLevel.Error)
-            .Enrich.FromLogContext()
-            .Enrich.With<GuidToEmojiEnricher>()
-            .WriteTo.Console(
-                outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"
-            )
-            .CreateLogger();
+        Log.Fatal("Bootstrap failed: {Reason}", result.ErrorMessage);
+        Console.Error.WriteLine($"Bootstrap failed: {result.ErrorMessage}");
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- Reorder `Program.Main` so the bootstrapper runs first, then `PreloadCudaRuntime` pins the bootstrapped CUDA/cuDNN redistributables into the Windows loader, and only then do `PreloadLlamaBackend` and `OrtEnv.Instance()` run — both transitively import `cudart64_12.dll`/`cublas64_12.dll`.
- Split `Program.cs` for SRP: new `NativeLibraryLoader` owns P/Invoke + preload (modern `LibraryImport` source generator); new `LoggingConfiguration` owns Serilog setup, global exception handlers, LLama log bridge, and ONNX log suppression. `Program.cs` goes from 285 → ~120 lines.
- Enable `AllowUnsafeBlocks` in `PersonaEngine.App.csproj` (required by the `LibraryImport` source generator).

## Bug
Users without a global CUDA install on `PATH` hit `DllNotFoundException: Failed to load …\cuda12\llama.dll` at startup. The bootstrapper downloads the CUDA DLLs under `Resources/cuda/`, but `Program.Main` pre-loaded `llama.dll` (which transitively imports `cudart64_12.dll` via `ggml-cuda.dll`) **before** `PreloadCudaRuntime` registered those DLLs with the loader. Systems with global CUDA on `PATH` resolved by luck — everyone else crashed.

## Test plan
- [x] Reproduced the crash on this machine by stripping CUDA from `PATH` and launching the smoke publish artifact → `DllNotFoundException` at `Program.cs:61`.
- [x] Applied the fix + refactor, rebuilt & re-published, re-ran the exact same scenario → app now reports `CUDA: Execution provider available`, ONNX sessions create successfully, conversation session runs to `Idle`, exit code `0`.
- [x] `dotnet build` clean, `csharpier check` clean.