### PR TITLE
feat(app): skip bootstrapper in dev via --skip-bootstrap flag and env var

### DIFF
--- a/src/PersonaEngine/PersonaEngine.App/Program.cs
+++ b/src/PersonaEngine/PersonaEngine.App/Program.cs
@@ -29,8 +29,22 @@ internal static class Program
         // Bootstrap runs before IConfiguration is built, so it sees only CLI args
         // and the embedded manifest — any future bootstrap setting must be a CLI
         // flag, not an appsettings.json entry.
+        //
+        // Dev escape hatch: when --skip-bootstrap is passed or the env var
+        // PERSONAENGINE_SKIP_BOOTSTRAP is truthy (set automatically by
+        // Properties/launchSettings.json in VS / Rider / `dotnet run`), we skip
+        // the runner entirely. Assets under Resources/ must then already be
+        // populated out-of-band — the CUDA preload below will log and move on
+        // if they aren't, and downstream subsystems will surface clearer errors.
         var parsedArgs = CommandLineArgs.Parse(args);
-        if (!await RunBootstrapAsync(parsedArgs).ConfigureAwait(false))
+        if (ShouldSkipBootstrap(parsedArgs, out var skipReason))
+        {
+            Log.Warning(
+                "Skipping bootstrap ({Reason}). Assets under Resources/ must already be populated.",
+                skipReason
+            );
+        }
+        else if (!await RunBootstrapAsync(parsedArgs).ConfigureAwait(false))
         {
             await Log.CloseAndFlushAsync();
             return 1;
@@ -83,6 +97,46 @@ internal static class Program
         window.Run();
 
         return 0;
+    }
+
+    /// <summary>
+    ///     Env var consulted to skip the bootstrapper without a CLI flag. Any of
+    ///     <c>1</c>, <c>true</c>, <c>yes</c> (case-insensitive, whitespace-trimmed) enables skip.
+    ///     Set automatically by <c>Properties/launchSettings.json</c> so VS / Rider /
+    ///     <c>dotnet run</c> never trigger the bootstrapper in a dev checkout.
+    /// </summary>
+    private const string SkipBootstrapEnvVar = "PERSONAENGINE_SKIP_BOOTSTRAP";
+
+    /// <summary>
+    ///     Resolves the dev-mode skip signal from CLI args or environment.
+    ///     <paramref name="reason" /> is the human-readable source of the signal, suitable
+    ///     for a single log line; it is only meaningful when the method returns <c>true</c>.
+    /// </summary>
+    private static bool ShouldSkipBootstrap(CommandLineArgs args, out string reason)
+    {
+        if (args.SkipBootstrap)
+        {
+            reason = "--skip-bootstrap flag";
+            return true;
+        }
+
+        var raw = Environment.GetEnvironmentVariable(SkipBootstrapEnvVar)?.Trim();
+        if (IsTruthy(raw))
+        {
+            reason = $"{SkipBootstrapEnvVar}={raw}";
+            return true;
+        }
+
+        reason = string.Empty;
+        return false;
+
+        static bool IsTruthy(string? value) =>
+            value is not null
+            && (
+                value.Equals("1", StringComparison.Ordinal)
+                || value.Equals("true", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("yes", StringComparison.OrdinalIgnoreCase)
+            );
     }
 
     /// <summary>

--- a/src/PersonaEngine/PersonaEngine.App/Properties/launchSettings.json
+++ b/src/PersonaEngine/PersonaEngine.App/Properties/launchSettings.json
@@ -1,0 +1,16 @@
+{
+  "profiles": {
+    "PersonaEngine": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "PERSONAENGINE_SKIP_BOOTSTRAP": "1"
+      }
+    },
+    "PersonaEngine (with bootstrap)": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "PERSONAENGINE_SKIP_BOOTSTRAP": ""
+      }
+    }
+  }
+}

--- a/src/PersonaEngine/PersonaEngine.Lib.Bootstrapper.Tests/CommandLineArgsTests.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib.Bootstrapper.Tests/CommandLineArgsTests.cs
@@ -60,6 +60,20 @@ public sealed class CommandLineArgsTests
     }
 
     [Fact]
+    public void SkipBootstrap_flag_is_recognized()
+    {
+        var parsed = CommandLineArgs.Parse(new[] { "--skip-bootstrap" });
+        parsed.SkipBootstrap.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SkipBootstrap_defaults_to_false()
+    {
+        var parsed = CommandLineArgs.Parse(Array.Empty<string>());
+        parsed.SkipBootstrap.Should().BeFalse();
+    }
+
+    [Fact]
     public void Unknown_args_are_ignored_without_failing_known_flags()
     {
         // Unknown args were originally captured into a PassThrough list; that

--- a/src/PersonaEngine/PersonaEngine.Lib.Bootstrapper/CommandLineArgs.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib.Bootstrapper/CommandLineArgs.cs
@@ -7,12 +7,20 @@ public sealed record CommandLineArgs
     public required BootstrapOptions Bootstrap { get; init; }
     public required bool NonInteractive { get; init; }
 
+    /// <summary>
+    ///     When <c>true</c>, the host should short-circuit <see cref="BootstrapRunner" />
+    ///     entirely. Intended for developer / CI scenarios where assets under
+    ///     <c>Resources/</c> are already managed out-of-band.
+    /// </summary>
+    public required bool SkipBootstrap { get; init; }
+
     public static CommandLineArgs Parse(IReadOnlyList<string> args)
     {
         var mode = BootstrapMode.AutoIfMissing;
         ProfileTier? profile = null;
         var nonInteractive = false;
         var skipGpuCheck = false;
+        var skipBootstrap = false;
 
         foreach (var arg in args)
         {
@@ -36,6 +44,9 @@ public sealed record CommandLineArgs
                 case "--skip-gpu-check":
                     skipGpuCheck = true;
                     break;
+                case "--skip-bootstrap":
+                    skipBootstrap = true;
+                    break;
                 case var s when s.StartsWith("--profile=", StringComparison.Ordinal):
                     profile = ParseProfile(s.Substring("--profile=".Length));
                     break;
@@ -57,6 +68,7 @@ public sealed record CommandLineArgs
                 SkipGpuCheck = skipGpuCheck,
             },
             NonInteractive = nonInteractive,
+            SkipBootstrap = skipBootstrap,
         };
     }
 


### PR DESCRIPTION
## Summary
- Adds `--skip-bootstrap` CLI flag and `PERSONAENGINE_SKIP_BOOTSTRAP` env var gate in `Program.Main` to short-circuit `BootstrapRunner` when assets under `Resources/` are already managed out-of-band.
- Ships `Properties/launchSettings.json` with two profiles so VS / Rider / `dotnet run` set the env var automatically — dev checkouts never trigger the bootstrapper unless explicitly requested.
- Unit tests cover the new CLI flag (`SkipBootstrap_flag_is_recognized`, `SkipBootstrap_defaults_to_false`).

## Test plan
- [x] `dotnet test src/PersonaEngine/PersonaEngine.Lib.Bootstrapper.Tests` — 15/15 pass
- [x] `dotnet run --project PersonaEngine.App` emits `[WRN] Skipping bootstrap (PERSONAENGINE_SKIP_BOOTSTRAP=1)...` confirming the env-var gate fires before `RunBootstrapAsync`
- [x] Published build still runs the bootstrapper normally (flag/env var absent)