### PR TITLE
Add Atlas Cloud endpoint preset

### DIFF
--- a/src/PersonaEngine/PersonaEngine.Lib.Tests/UI/ControlPanel/Panels/Shared/EndpointPickerRowTests.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib.Tests/UI/ControlPanel/Panels/Shared/EndpointPickerRowTests.cs
@@ -1,0 +1,27 @@
+using PersonaEngine.Lib.UI.ControlPanel.Panels.Shared;
+using Xunit;
+
+namespace PersonaEngine.Lib.Tests.UI.ControlPanel.Panels.Shared;
+
+public class EndpointPickerRowTests
+{
+    [Fact]
+    public void DefaultPresets_IncludeAtlasCloudEndpoint()
+    {
+        var preset = Assert.Single(
+            EndpointPickerRow.DefaultPresets,
+            item => item.Label == "Atlas Cloud"
+        );
+
+        Assert.Equal("https://api.atlascloud.ai/v1", preset.Url);
+    }
+
+    [Fact]
+    public void DefaultPresets_DoNotDuplicateLabels()
+    {
+        Assert.Equal(
+            EndpointPickerRow.DefaultPresets.Length,
+            EndpointPickerRow.DefaultPresets.Select(item => item.Label).Distinct().Count()
+        );
+    }
+}

--- a/src/PersonaEngine/PersonaEngine.Lib/UI/ControlPanel/Panels/Shared/EndpointPickerRow.cs
+++ b/src/PersonaEngine/PersonaEngine.Lib/UI/ControlPanel/Panels/Shared/EndpointPickerRow.cs
@@ -17,11 +17,12 @@ public static class EndpointPickerRow
 {
     /// <summary>
     ///     Default preset list shared by every LLM connection section (text + vision).
-    ///     OpenAI public endpoint + the two locally-hosted OpenAI-compatible runtimes.
+    ///     Hosted OpenAI-compatible APIs plus locally-hosted runtimes.
     /// </summary>
     public static readonly ImmutableArray<(string Label, string Url)> DefaultPresets =
     [
         ("OpenAI", "https://api.openai.com/v1"),
+        ("Atlas Cloud", "https://api.atlascloud.ai/v1"),
         ("LM Studio", "http://localhost:1234/v1"),
         ("Ollama", "http://localhost:11434/v1"),
     ];


### PR DESCRIPTION
## Summary
- Add Atlas Cloud to the existing OpenAI-compatible endpoint presets.
- Add focused tests that lock the Atlas Cloud preset URL and guard against duplicate preset labels.

## Validation
- `git diff --check`
- Live Atlas Cloud `/v1/models` check returned 119 models and confirmed `qwen/qwen3.5-flash` plus `deepseek-ai/deepseek-v4-pro`

Not run locally:
- `dotnet test` because `dotnet` is not installed in this environment.

No README changes.
